### PR TITLE
Replace facets * operator with merge

### DIFF
--- a/lib/buildr/ivy_extension.rb
+++ b/lib/buildr/ivy_extension.rb
@@ -201,7 +201,7 @@ module Buildr
           unless @published
             base_options = {:pubrevision => revision, :artifactspattern => "#{publish_from}/[artifact].[ext]"}
             base_options[:status] = status if status
-            options = publish_options * base_options
+            options = base_options.merge publish_options
             ivy4r.publish options
             @published = true
           end


### PR DESCRIPTION
The facets dependency is gone, but the publish method still depends on the \* operator on hashes (defined in facets).
This pull request fixes that issue.
